### PR TITLE
Set sitemap.xml & robots.txt + Typesafe Env with t3-env

### DIFF
--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@t3-oss/env-nextjs": "^0.13.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "flag-icons": "^7.5.0",
@@ -28,7 +29,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-spring": "^1.0.1"
+    "tailwindcss-spring": "^1.0.1",
+    "zod": "^4.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/front/src/app/robots.ts
+++ b/apps/front/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next'
+
+import { env } from '@/lib/env'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/'
+    },
+    sitemap: env.NEXT_PUBLIC_FRONT_URL + '/sitemap.xml'
+  }
+}

--- a/apps/front/src/app/sitemap.ts
+++ b/apps/front/src/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+import { env } from '@/lib/env'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: env.NEXT_PUBLIC_FRONT_URL,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1
+    }
+  ]
+}

--- a/apps/front/src/lib/env.ts
+++ b/apps/front/src/lib/env.ts
@@ -1,0 +1,18 @@
+import { createEnv } from '@t3-oss/env-nextjs'
+import { z } from 'zod'
+
+if (process.env.VERCEL_ENV) {
+  process.env.NEXT_PUBLIC_FRONT_URL = `https://${process.env.VERCEL_URL}`
+}
+
+export const env = createEnv({
+  client: {
+    NEXT_PUBLIC_FRONT_URL: z.url()
+  },
+  server: {
+    NODE_ENV: z.enum(['production', 'development', 'preview', 'local'])
+  },
+  experimental__runtimeEnv: {
+    NEXT_PUBLIC_FRONT_URL: process.env.NEXT_PUBLIC_FRONT_URL
+  }
+})

--- a/apps/front/src/middleware.ts
+++ b/apps/front/src/middleware.ts
@@ -6,5 +6,5 @@ export default createMiddleware(routing)
 
 export const config = {
   matcher:
-    '/((?!api|_next/static|_next/image|assets|images|icons|icons|sw.js|site.webmanifest|robots.txt|manifest.json|\\.well-known).*)'
+    '/((?!api|_next/static|_next/image|assets|images|icons|sw.js|site.webmanifest|robots.txt|manifest.json|sitemap.xml|\\.well-known).*)'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@t3-oss/env-nextjs':
+        specifier: ^0.13.8
+        version: 0.13.8(typescript@5.9.2)(zod@4.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -84,6 +87,9 @@ importers:
       tailwindcss-spring:
         specifier: ^1.0.1
         version: 1.0.1(tailwindcss@4.1.12)
+      zod:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -830,6 +836,40 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@t3-oss/env-core@0.13.8':
+    resolution: {integrity: sha512-L1inmpzLQyYu4+Q1DyrXsGJYCXbtXjC4cICw1uAKv0ppYPQv656lhZPU91Qd1VS6SO/bou1/q5ufVzBGbNsUpw==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
+  '@t3-oss/env-nextjs@0.13.8':
+    resolution: {integrity: sha512-QmTLnsdQJ8BiQad2W2nvV6oUpH4oMZMqnFEjhVpzU0h3sI9hn8zb8crjWJ1Amq453mGZs6A4v4ihIeBFDOrLeQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@tailwindcss/node@4.1.12':
     resolution: {integrity: sha512-3hm9brwvQkZFe++SBt+oLjo4OLDtkvlE8q2WalaD/7QWaeM7KEJbAiY/LJZUaCs7Xa8aUu4xy3uoyX4q54UVdQ==}
@@ -2835,6 +2875,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zod@4.1.0:
+    resolution: {integrity: sha512-UWxluYj2IDX9MHRXTMbB/2eeWrAMmmMSESM+MfT9MQw8U1qo9q5ASW08anoJh6AJ7pkt099fLdNFmfI+4aChHg==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -3436,6 +3479,18 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@t3-oss/env-core@0.13.8(typescript@5.9.2)(zod@4.1.0)':
+    optionalDependencies:
+      typescript: 5.9.2
+      zod: 4.1.0
+
+  '@t3-oss/env-nextjs@0.13.8(typescript@5.9.2)(zod@4.1.0)':
+    dependencies:
+      '@t3-oss/env-core': 0.13.8(typescript@5.9.2)(zod@4.1.0)
+    optionalDependencies:
+      typescript: 5.9.2
+      zod: 4.1.0
 
   '@tailwindcss/node@4.1.12':
     dependencies:
@@ -5604,3 +5659,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod@4.1.0: {}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["VERCEL_URL", "VERCEL_ENV", "NEXT_PUBLIC_FRONT_URL"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
- Added '@t3-oss/env-nextjs' and 'zod' to package.json for improved environment management and validation.
- Updated pnpm-lock.yaml to reflect new versions and peer dependencies for '@t3-oss/env-core' and '@t3-oss/env-nextjs'.
- Modified middleware.ts to exclude 'sitemap.xml' from the matcher for better routing control.

# Description

Closes #24
